### PR TITLE
Logging to file and console with `logging`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .idea
+vision.log

--- a/camera/camera_source.py
+++ b/camera/camera_source.py
@@ -3,6 +3,7 @@ import time
 from multiprocessing import Process
 from camera.camera_params import CameraParams
 from pipelines.base_pipeline import BasePipeline
+from logger import logger
 
 
 class CameraSource(Process):
@@ -20,6 +21,7 @@ class CameraSource(Process):
 
         # READ CONFIG FILE
         self.params = CameraParams(filename)
+        logger.info(f'Started Camera with id {self.params.cid}')
 
         self.pipelines = pipelines
 
@@ -30,6 +32,7 @@ class CameraSource(Process):
                 self.cap = cv2.VideoCapture(self.params.path)  # , cv2.CAP_V4L)
 
             _, self.frame = self.cap.read()
+            logger.debug(f'Frame received on CameraSource {self.params.cid}')
             ts = int(time.time() * 1000)  # Current time in ms
 
             # CALIBRATE IMAGE PIPE

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,20 @@
+import logging
+
+
+logger = logging.getLogger('grt_vision')
+logger.setLevel(logging.DEBUG)
+
+# Log INFO and above to console
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+
+# Log everything to file
+fh = logging.FileHandler('vision.log')
+fh.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter('[%(asctime)s - %(module)s %(levelname)s]: %(message)s')
+ch.setFormatter(formatter)
+fh.setFormatter(formatter)
+
+logger.addHandler(ch)
+logger.addHandler(fh)

--- a/networker.py
+++ b/networker.py
@@ -3,6 +3,7 @@ import time
 import zmq
 from multiprocessing import Process, SimpleQueue
 from util.jetson_data import JetsonData
+from logger import logger
 
 LOCAL_DEBUG = False
 SERVER_IP = "tcp://*:5800" if LOCAL_DEBUG else "tcp://10.1.92.94:5800"
@@ -14,14 +15,14 @@ RIO_IDENT = b"RIO"
 def networker(data_queue: SimpleQueue):
     context = zmq.Context()
 
-    print(f"Connecting a PUB server to {SERVER_IP}")
+    logger.info(f"Connecting a PUB server to {SERVER_IP}")
     socket = context.socket(zmq.PUB)
     socket.bind(SERVER_IP)
 
     # While the process is running, wait for messages in the queue and send them.
     while True:
         message = data_queue.get().to_json_str()
-        print(f"Sending data: {message}")
+        logger.debug(f"Sending data: {message}")
         socket.send_string(message)
 
 

--- a/pipelines/apriltag_pipeline.py
+++ b/pipelines/apriltag_pipeline.py
@@ -4,12 +4,13 @@ from pipelines.apriltag_pipe import apriltag_pipe
 from pipelines.draw_tags_pipe import draw_tags_pipe
 from pipelines.grayscale_pipe import grayscale_pipe
 from util.math_util import matrix_to_quat
+from logger import logger
 
 
 class AprilTagPipeline(BasePipeline):
     def process(self, image, params, ts):
         if image is None:
-            print('Pipeline: Received no image')
+            logger.warning('Received no image')
             return
 
         # GRAYSCALE PIPE
@@ -17,6 +18,7 @@ class AprilTagPipeline(BasePipeline):
 
         # Run tag detection
         detections = apriltag_pipe(gray_image, AprilTagParams('tag16h5'), params.get_params_april())
+        logger.info(f'Received {len(detections)} detections')
 
         # DRAW TAGS PIPE
         output_image = draw_tags_pipe(gray_image, detections)


### PR DESCRIPTION
Logs are formatted as
```
[2022-12-20 18:36:48,448 - networker INFO]: Connecting a PUB server to tcp://*:5800
```
with their timestamp, module name, log level, and message. `INFO` logs and above (warnings, errors, etc.) are logged to console, while all logs (including debug) are logged to the `vision.log` file.