### PR TITLE
Queue based logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__
 .idea
-vision.log
+vision.log.*

--- a/camera/camera_source.py
+++ b/camera/camera_source.py
@@ -1,6 +1,7 @@
+from typing import Tuple, Type
 import cv2
 import time
-from multiprocessing import Process, Queue
+from multiprocessing import Process, Queue, SimpleQueue
 from camera.camera_params import CameraParams
 from pipelines.base_pipeline import BasePipeline
 from logger import init_process_logging
@@ -12,7 +13,7 @@ class CameraSource(Process):
     config file (see `CameraParams`), and `pipelines` should be a list of pipelines this `CameraSource` owns
     (i.e. that this `CameraSource` sends frames to).
     """
-    def __init__(self, filename: str, log_queue: Queue, *pipelines: BasePipeline):
+    def __init__(self, filename: str, data_queue: SimpleQueue, stream_queue: SimpleQueue, log_queue: Queue, pipelines: Tuple[Type[BasePipeline]]):
         super().__init__()
 
         # Initialize objects
@@ -22,11 +23,12 @@ class CameraSource(Process):
         # READ CONFIG FILE
         self.params = CameraParams(filename)
 
-        # TODO: better way of passing around queues?
+        # Initialize logging
         self.logger = init_process_logging(log_queue)
         self.logger.info(f'Started Camera with id {self.params.cid}')
 
-        self.pipelines = pipelines
+        # Construct pipelines
+        self.pipelines = [Pipeline(data_queue, stream_queue, self.params, self.logger) for Pipeline in pipelines]
 
     def run(self) -> None:
         while True:
@@ -44,6 +46,6 @@ class CameraSource(Process):
 
             # Send frame to pipelines for processing
             for pipeline in self.pipelines:
-                pipeline.process(self.frame, self.params, self.logger, ts)
+                pipeline.process(self.frame, ts)
 
             time.sleep(1.0 / self.params.fps)

--- a/logger.py
+++ b/logger.py
@@ -1,20 +1,52 @@
 import logging
+import logging.handlers
+import time
+from multiprocessing import Queue
 
 
-logger = logging.getLogger('grt_vision')
-logger.setLevel(logging.DEBUG)
+def init_process_logging(log_queue: Queue) -> logging.Logger:
+    """
+    Initializes logging on a process. This *must* be called for logging to work.
+    :param log_queue: The `multiprocessing.Queue` that non-console logs should be broadcast to.
+    :return: The configured `Logger` object.
+    """
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
 
-# Log INFO and above to console
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
+    # Log INFO and above to console
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
 
-# Log everything to file
-fh = logging.FileHandler('vision.log')
-fh.setLevel(logging.DEBUG)
+    # Log everything to logging process
+    qh = logging.handlers.QueueHandler(log_queue)
+    qh.setLevel(logging.DEBUG)
 
-formatter = logging.Formatter('[%(asctime)s - %(module)s %(levelname)s]: %(message)s')
-ch.setFormatter(formatter)
-fh.setFormatter(formatter)
+    formatter = logging.Formatter('[%(asctime)s - %(module)s %(levelname)s]: %(message)s')
+    ch.setFormatter(formatter)
+    qh.setFormatter(formatter)
 
-logger.addHandler(ch)
-logger.addHandler(fh)
+    root.addHandler(ch)
+    root.addHandler(qh)
+
+    return root
+
+
+# TODO: better name and combine with DS websocket process
+def file_logger(log_queue: Queue) -> None:
+    """
+    A logger process that reads logs from a `log_queue` and writes them to a timestamped logfile.
+    :param log_queue: The `multiprocessing.Queue` to read logs from.
+    """
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+
+    # Log everything to file
+    fh = logging.FileHandler(f'vision.log.{int(time.time() * 1000)}')
+    fh.setLevel(logging.DEBUG)
+
+    root.addHandler(fh)
+
+    while True:
+        record = log_queue.get()
+        logger = logging.getLogger(record.name)
+        logger.handle(record)

--- a/main.py
+++ b/main.py
@@ -13,15 +13,18 @@ if __name__ == '__main__':
 
     sources = [
         CameraSource(  # Camera A
-            "...",
-            log_queue,
-            GreenLightPipeline(data_queue, stream_queue),
-            AprilTagPipeline(data_queue, stream_queue)
+            filename="...",
+            data_queue=data_queue,
+            stream_queue=stream_queue,
+            log_queue=log_queue,
+            pipelines=(GreenLightPipeline, AprilTagPipeline)  # TODO: not sure why this gives a type warning but the below doesn't
         ),
         CameraSource(  # Camera B
-            "...",
-            log_queue,
-            AprilTagPipeline(data_queue, stream_queue)
+            filename="...",
+            data_queue=data_queue,
+            stream_queue=stream_queue,
+            log_queue=log_queue,
+            pipelines=(AprilTagPipeline,)
         )
     ]
 

--- a/main.py
+++ b/main.py
@@ -1,31 +1,35 @@
-from multiprocessing import Process, SimpleQueue
+from multiprocessing import Process, SimpleQueue, Queue
 from networker import networker
 from pipelines.apriltag_pipeline import AprilTagPipeline
 from pipelines.greenlight_pipeline import GreenLightPipeline
 from camera.camera_source import CameraSource
+from logger import file_logger
 
 
 if __name__ == '__main__':
     data_queue = SimpleQueue()
     stream_queue = SimpleQueue()
+    log_queue = Queue()
 
     sources = [
         CameraSource(  # Camera A
             "...",
+            log_queue,
             GreenLightPipeline(data_queue, stream_queue),
             AprilTagPipeline(data_queue, stream_queue)
         ),
         CameraSource(  # Camera B
             "...",
+            log_queue,
             AprilTagPipeline(data_queue, stream_queue)
         )
     ]
 
-    # networker_process = Process(target=networker, args=(data_queue,), daemon=True)
-    # networker_process.start()
+    networker_process = Process(target=networker, args=(data_queue, log_queue), daemon=True)
+    networker_process.start()
 
     # Start `CameraSource` processes
     for source in sources:
         source.start()
 
-    networker(data_queue)
+    file_logger(log_queue)

--- a/networker.py
+++ b/networker.py
@@ -1,19 +1,25 @@
 from random import Random
 import time
 import zmq
-from multiprocessing import Process, SimpleQueue
+from multiprocessing import Process, SimpleQueue, Queue
 from util.jetson_data import JetsonData
-from logger import logger
+from logger import init_process_logging, file_logger
 
 LOCAL_DEBUG = False
 SERVER_IP = "tcp://*:5800" if LOCAL_DEBUG else "tcp://10.1.92.94:5800"
 RIO_IDENT = b"RIO"
 
 
-# A networker that sends data to the RoboRIO over a PUB/SUB connection.
-# Data is queued to be sent via the `data_queue`, and is broadcast as fast as it arrives.
-def networker(data_queue: SimpleQueue):
+#
+def networker(data_queue: SimpleQueue, log_queue: Queue) -> None:
+    """
+    A networker process that sends vision data to the RoboRIO over a PUB/SUB connection. Data is queued to be sent via
+    the `data_queue`, and is broadcast as fast as it arrives.
+    :param data_queue: The `multiprocessing.SimpleQueue` to read data from.
+    :param log_queue: The `multiprocessing.Queue` to broadcast logs to.
+    """
     context = zmq.Context()
+    logger = init_process_logging(log_queue)
 
     logger.info(f"Connecting a PUB server to {SERVER_IP}")
     socket = context.socket(zmq.PUB)
@@ -29,9 +35,13 @@ def networker(data_queue: SimpleQueue):
 if __name__ == '__main__':
     random = Random()
     data_queue = SimpleQueue()
+    log_queue = Queue()
 
-    networker_process = Process(target=networker, args=(data_queue,), daemon=True)
+    networker_process = Process(target=networker, args=(data_queue, log_queue), daemon=True)
     networker_process.start()
+
+    logger_process = Process(target=file_logger, args=(log_queue,), daemon=True)
+    logger_process.start()
 
     # Test the networker by continually sending semi-random data
     while True:

--- a/pipelines/apriltag_pipeline.py
+++ b/pipelines/apriltag_pipeline.py
@@ -7,17 +7,17 @@ from util.math_util import matrix_to_quat
 
 
 class AprilTagPipeline(BasePipeline):
-    def process(self, image, params, logger, ts):
+    def process(self, image, ts):
         if image is None:
-            logger.warning('Received no image')
+            self.logger.warning('Received no image')
             return
 
         # GRAYSCALE PIPE
         gray_image = grayscale_pipe(image)
 
         # Run tag detection
-        detections = apriltag_pipe(gray_image, AprilTagParams('tag16h5'), params.get_params_april())
-        logger.info(f'Received {len(detections)} detections')
+        detections = apriltag_pipe(gray_image, AprilTagParams('tag16h5'), self.params.get_params_april())
+        self.logger.info(f'Received {len(detections)} detections')
 
         # DRAW TAGS PIPE
         output_image = draw_tags_pipe(gray_image, detections)
@@ -27,7 +27,6 @@ class AprilTagPipeline(BasePipeline):
                 translation=(d.pose_t[0][0], d.pose_t[1][0], d.pose_t[2][0]),  # unpack tvec array
                 rotation=matrix_to_quat(d.pose_R),
                 ts=ts,
-                cid=params.cid,
                 tid=d.tag_id
             )
 

--- a/pipelines/apriltag_pipeline.py
+++ b/pipelines/apriltag_pipeline.py
@@ -4,11 +4,10 @@ from pipelines.apriltag_pipe import apriltag_pipe
 from pipelines.draw_tags_pipe import draw_tags_pipe
 from pipelines.grayscale_pipe import grayscale_pipe
 from util.math_util import matrix_to_quat
-from logger import logger
 
 
 class AprilTagPipeline(BasePipeline):
-    def process(self, image, params, ts):
+    def process(self, image, params, logger, ts):
         if image is None:
             logger.warning('Received no image')
             return

--- a/pipelines/base_pipeline.py
+++ b/pipelines/base_pipeline.py
@@ -7,31 +7,31 @@ from logging import Logger
 
 class BasePipeline:
     """
-    The base pipeline, initialized with a data and stream queue. The `CameraSource` that owns this pipeline
-    periodically calls `process(image)` with a new frame of data.
+    The base pipeline, initialized with a data and stream queue and `CameraSource`-specific parameters. The
+    `CameraSource` that owns this pipeline periodically calls `process(image)` with new frames of data.
     """
-    def __init__(self, data_queue: SimpleQueue, stream_queue: SimpleQueue):
+    def __init__(self, data_queue: SimpleQueue, stream_queue: SimpleQueue, params: CameraParams, logger: Logger):
         self.data_queue = data_queue
         self.stream_queue = stream_queue
 
-    def process(self, image, params: CameraParams, logger: Logger, ts: int) -> None:
+        self.params = params
+        self.logger = logger
+
+    def process(self, image, ts: int) -> None:
         """
         Processes a frame from a `CameraSource`. This method should call `_broadcast_data()` with data to send it
         to the RIO.
         :param image: The image frame to process.
-        :param params: The camera params of the invoking `CameraSource`.
-        :param logger: The `logging.Logger` to log to.
         :param ts: The timestamp the image frame was captured at.
         """
         raise Exception('Not implemented!')
 
-    def _broadcast_data(self, translation: Translation, rotation: Quaternion, ts: int, tid: int, cid: int) -> None:
+    def _broadcast_data(self, translation: Translation, rotation: Quaternion, ts: int, tid: int) -> None:
         """
         Queues data to be broadcast to the RIO.
         :param translation: The translation `(x, y, z)` of the target relative to the camera.
         :param rotation: The quaternion rotation `(w, x, y, z) of the target relative to the camera.
         :param ts: The `CameraSource` provided timestamp of the camera frame.
         :param tid: The id of the target (0-29 for AprilTags, 30+ for custom targets).
-        :param cid: The id of the camera.
         """
-        self.data_queue.put(JetsonData(translation, rotation, ts, tid, cid))
+        self.data_queue.put(JetsonData(translation, rotation, ts, tid, self.params.cid))

--- a/pipelines/base_pipeline.py
+++ b/pipelines/base_pipeline.py
@@ -2,6 +2,7 @@ from multiprocessing import SimpleQueue
 from camera.camera_params import CameraParams
 from util.math_util import Translation, Quaternion
 from util.jetson_data import JetsonData
+from logging import Logger
 
 
 class BasePipeline:
@@ -13,12 +14,13 @@ class BasePipeline:
         self.data_queue = data_queue
         self.stream_queue = stream_queue
 
-    def process(self, image, params: CameraParams, ts: int) -> None:
+    def process(self, image, params: CameraParams, logger: Logger, ts: int) -> None:
         """
         Processes a frame from a `CameraSource`. This method should call `_broadcast_data()` with data to send it
         to the RIO.
         :param image: The image frame to process.
         :param params: The camera params of the invoking `CameraSource`.
+        :param logger: The `logging.Logger` to log to.
         :param ts: The timestamp the image frame was captured at.
         """
         raise Exception('Not implemented!')

--- a/pipelines/greenlight_pipeline.py
+++ b/pipelines/greenlight_pipeline.py
@@ -7,5 +7,5 @@ from pipelines.base_pipeline import BasePipeline
 # ex: (0, 1.5, 1)
 
 class GreenLightPipeline(BasePipeline):
-    def process(self, image, params, logger, ts):
+    def process(self, image, ts):
         return

--- a/pipelines/greenlight_pipeline.py
+++ b/pipelines/greenlight_pipeline.py
@@ -7,5 +7,5 @@ from pipelines.base_pipeline import BasePipeline
 # ex: (0, 1.5, 1)
 
 class GreenLightPipeline(BasePipeline):
-    def process(self, image, params, ts):
+    def process(self, image, params, logger, ts):
         return


### PR DESCRIPTION
Implements generating a new logfile per run, and also fixes [logging to the same file from multiple processes](https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes) by using `QueueHandler` for all non-console logs in each process and running a separate logging process that writes the queued logs to file (and eventually to the DS websocket as well). The implementation is not as clean as before though, and it may be worth thinking about how all these different queues should be passed around.

<img width="230" alt="image" src="https://user-images.githubusercontent.com/60120929/210022386-bd5abcf3-fbd5-4942-91bf-71677576d585.png">
